### PR TITLE
Nested quotes fixed

### DIFF
--- a/main.py
+++ b/main.py
@@ -46,4 +46,4 @@ for prompt in prompts:
 
 # Log time series statistics
 df = pd.DataFrame(time_series, columns=['Tokens per Second'])
-logger.info(f'Time series statistics: {df['Tokens per Second'].describe()}')
+logger.info(f'Time series statistics: {df["Tokens per Second"].describe()}')


### PR DESCRIPTION
Nested quotes generates error message in python3.11 environment:

    logger.info(f'Time series statistics: {df['Tokens per Second'].describe()}')
                                               ^^^^^^
SyntaxError: f-string: unmatched '['

